### PR TITLE
Remove Docker from ubuntu-dev container image

### DIFF
--- a/dev-container-basic/Dockerfile
+++ b/dev-container-basic/Dockerfile
@@ -3,12 +3,9 @@ FROM ubuntu:24.04
 
 # Install APT packages required for core development tools
 RUN apt update &&\
-    apt install -y build-essential zsh git curl jq &&\
+    apt install -y build-essential sudo zsh git curl jq &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
-
-# Install Docker
-RUN curl -fsSL https://get.docker.com | sh
 
 # Install Go
 # --> Relies on `export PATH=/usr/local/go/bin:$PATH` in .zshrc file
@@ -16,22 +13,27 @@ RUN curl -sO https://dl.google.com/go/go1.23.2.linux-arm64.tar.gz &&\
     tar -xzvf go1.23.2.linux-arm64.tar.gz -C /usr/local &&\
     rm go1.23.2.linux-arm64.tar.gz
 
-# Create a new non-root user and switch to them
+# Install uv and Python
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh &&\
+    uv python install 3.12 3.13 &&\
+    uv python pin 3.12
+
+# Create a new:
+# --> give them password-less sudo privilages
+# --> create directories for binding local OS directories
 RUN useradd --create-home dev &&\
-    usermod -aG docker dev
+    usermod -aG sudo dev &&\
+    echo "dev ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers &&\
+    mkdir /home/dev/.ssh &&\
+    mkdir /home/dev/workspace
+
+# login as new user and change working directory
 USER dev
 WORKDIR /home/dev
-RUN mkdir .ssh &&\
-    mkdir workspace
 
 # Install user specific tools:
 # - Oh My Zsh
-# - uv + Python
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh &&\
-    export PATH=$HOME/.cargo/bin:$PATH &&\
-    uv python install 3.12 3.13 &&\
-    uv python pin 3.12
 
 # Copy Zsh shell config
 COPY .zshrc .zshrc

--- a/dev-container-basic/README.md
+++ b/dev-container-basic/README.md
@@ -4,7 +4,6 @@ This `Dockerfile` defines an Ubuntu Linux image into which all of my favourite d
 
 - Go
 - Python (via [uv](https://docs.astral.sh/uv/))
-- Docker
 
 And a few other useful tools - see the Dockerfile for more info.
 


### PR DESCRIPTION
Taking the advice that Docker-in-Docker should not be attempted on an ad hoc basis. This PR also fixes a bug with uv that came when installing the latest version.