### PR TITLE
Developer Tool Configuration

### DIFF
--- a/dev-config/README.md
+++ b/dev-config/README.md
@@ -1,0 +1,5 @@
+# Developer Tool Config Files
+
+Files that define preferences for various developer tools:
+
+- `ruff.toml` - for the [Ruff](https://docs.astral.sh/ruff/) Python linter.

--- a/dev-config/ruff.toml
+++ b/dev-config/ruff.toml
@@ -1,0 +1,14 @@
+line-length = 88
+lint.select = [
+  "D",   # pydocstyle
+  "E",   # pycodestyle errors
+  "F",   # pyflakes
+  "I",   # isort
+  "UP",  # pyupgrade
+  "W",   # pycodestyle warnings
+]
+lint.ignore = [
+  "D105",    # fix pydocstyle warning    
+  "D203",    # fix pydocstyle warning
+  "D213",    # fix pydocstyle warning
+]


### PR DESCRIPTION
A directory for developer tool config files.

**Added**

- `dev-config/README.md` - brief summary.
- `dev-configruff.toml` - my config preferences for using Ruff.